### PR TITLE
BREAKING: Make ACL optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ function CDNUp(bucket, options) {
   this.check = options.check;
   this.bucket = bucket;
   this.client = pkgcloud.storage.createClient(options.pkgcloud || {});
-  this.acl = options.acl || 'public-read';
+  if ('acl' in options) {
+    this.acl = options.acl || 'public-read';
+  }
   this.subdomain = options.subdomain;
 }
 


### PR DESCRIPTION
> As a general rule, AWS recommends using S3 bucket policies or IAM policies for access control. S3 ACLs is a legacy access control mechanism that predates IAM. However, if you already use S3 ACLs and you find them sufficient, there is no need to change.

https://aws.amazon.com/blogs/security/iam-policies-and-bucket-policies-and-acls-oh-my-controlling-access-to-s3-resources/

Currently to use cdnup you _must_ provide an ACL that is used on a per-file basis, there's no mechanism to let it default to how the S3 bucket is configured for access.

Verified for my usecase that the below works.  I haven't included unit tests because they're currently [unrunable](https://github.com/warehouseai/cdnup/blob/master/test/cdnup-test.js#L13-L17)