### PR TITLE
[minor] use localstack and a simple config to run tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#16] Ensure unit tests can run and fix error detection for missing bucket
 - [#13] new file.contentEncoding API to replace file.contentType
 
 - [#12] Add collected documentation and badges.
@@ -8,6 +9,7 @@
   - Update dependencies
 
 [#8]: https://github.com/warehouseai/cdnup/issues/8
-[#13]: https://github.com/warehouseai/cdnup/pull/13
 
-[#12]: https://github.com/warehouseai/extract-config/pull/12
+[#12]: https://github.com/warehouseai/cdnup/pull/12
+[#13]: https://github.com/warehouseai/cdnup/pull/13
+[#16]: https://github.com/warehouseai/cdnup/pull/16

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ const fileURL = cdn.checkUrl('https://whatever.com/world/hello-fixture.js');
 
 ### Test
 
+Run AWS local, pull `latest` [localstack].
+This requires `docker` [to be setup][docker].
+
+```sh
+docker pull localstack/localstack:latest
+npm run localstack
+```
+
+Finally, run the unit test.
+
 ```bash
 npm test
 ```
@@ -136,3 +146,4 @@ npm test
 [pkgcloud]: https://github.com/pkgcloud/pkgcloud
 [forcepath]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property
 [BFFS]: https://github.com/warehouseai/bffs/blob/84354709fc0dc909341d72fed1466b46b130f655/index.js#L105-L118
+[localstack]: https://github.com/localstack/localstack

--- a/file.js
+++ b/file.js
@@ -105,7 +105,7 @@ File.prototype.attempt = function attempt(action, fn) {
   if (file.retries) action(one(function next(err) {
     if (!err) return fn.apply(this, arguments);
 
-    if (err && typeof err === 'string' && /NoSuchBucket/.test(err)) {
+    if (err && err.code === 'NoSuchBucket') {
       return file.cdn.init((error) => {
         if (error) return fn(error);
 

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ CDNUp.prototype.url = function () {
     || (this.client.protocol
       + (this.subdomain ? `${this.bucket}.` : '')
       + this.client.endpoint);
+
   //
   // Needs to end with `/` or the URL.resolve will replace the last path.
   //

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha test/*-test.js",
     "eslint": "eslint-godaddy -c .eslintrc test/ ./*.js",
-    "pretest": "npm run eslint"
+    "posttest": "npm run eslint",
+    "localstack": "docker run -it -p 4572:4572 --rm localstack/localstack"
   },
   "repository": {
     "type": "git",

--- a/test/cdnup-test.js
+++ b/test/cdnup-test.js
@@ -12,6 +12,7 @@ describe('cdnup', function () {
   var fixture = require('path').resolve(__dirname, 'fixture.js');
   var config = require('./mock-config');
   var root = config.prefix || 'cdnup';
+
   //
   // Define a local var so we override it.
   //
@@ -19,20 +20,15 @@ describe('cdnup', function () {
 
   function subdomainConfig() {
     const conf = clone(config);
-    delete conf.pkgcloud.forceBucketPath;
+    conf.pkgcloud.forcePathBucket = false;
     conf.subdomain = true;
+
     return conf;
   }
-  //
-  // Mounting a drive, can take really long depending on your geographical
-  // location.
-  //
-  this.timeout(60000);
 
   beforeEach(function () {
     cdnup = new CDNUp(root, config);
   });
-
 
   it('exports as a function', function () {
     assume(CDNUp).is.a('function');
@@ -89,6 +85,7 @@ describe('cdnup', function () {
       const conf = subdomainConfig();
       const cdn = new CDNUp(conf.prefix, conf);
       const uri = resolve(cdn.url(), 'hello-fixture.js');
+
       assume(uri).startsWith(`https://${cdnup.bucket}`);
     });
 

--- a/test/mock-config.js
+++ b/test/mock-config.js
@@ -1,2 +1,15 @@
+const endpoint = 'http://localhost:4572';
+const bucket = 'test-cdnup';
+
 module.exports = {
+  check: `${ endpoint }/${ bucket }/`,
+  acl: 'public-read',
+  prefix: bucket,
+  pkgcloud: {
+    accessKeyId: 'fakeId',
+    secretAccessKey: 'fakeKey',
+    provider: 'amazon',
+    forcePathBucket: true,
+    endpoint
+  }
 };


### PR DESCRIPTION
## Summary
Retry logic seemed broken when working on `bffs`. But it was actually the detection of a returned error from `pkgcloud`/`aws`. Which is now a regular `Error` with a `code`, rather than a string.

## Changelog

Updated.

## Test Plan

See updated readme.

```
npm run localstack
npm test
```
